### PR TITLE
Allow retrieving infile and outfile as path

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,10 @@ the program will quit. A default can be specified, so "(default stdin)" will
 wrap up `io.stdin()` for you if the flag is not provided. (This is why we return
 boxed trait objects rather than actual `File` objects - to handle this case.)
 
+"infile" and "outfile" also act like "path" values and the path given on the
+command line can be retrieved with `.get_path()` or `.get_path_result()` as with any
+other path.
+
 By default, the accessor functions exit the program on error. But for every method
 like `args.get_string("flag")` there is an error-returning `args.get_string_result("flag")`.
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -212,6 +212,8 @@ impl Value {
     pub fn as_path(&self) -> Result<PathBuf> {
         match *self {
             Value::Path(ref p) => Ok(p.clone()),
+            Value::FileIn(ref s) => Ok(s.clone().into()),
+            Value::FileOut(ref s) => Ok(s.clone().into()),
             _ => self.type_error("path")
 
         }


### PR DESCRIPTION
This permits the user to check that the two are not pointing to the same
file, which is important when reading and writing in a streaming
fashion, as this would lead the file to be deleted.