### PR TITLE
lapp-gen Cleanup

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,7 +190,7 @@ This is passed to `lapp-gen` as an environment variable (since we don't want to
 confuse the command-line parameters here)
 
 ```
-~/rust/lapp/examples$ LAPP_FILE='test.lapp vars' lapp-gen
+~/rust/lapp/examples$ LAPP_GEN='test.lapp vars' lapp-gen
     let lines = args.get_integer("lines");
     let verbose = args.get_bool("verbose");
     let file = args.get_string("file");
@@ -204,22 +204,22 @@ is prepended with 'c_'.
 You may test your spec by specifying just the file, and any command-line arguments:
 
 ```
-~/rust/lapp/examples$ LAPP_FILE='test.lapp' lapp-gen
+~/rust/lapp/examples$ LAPP_GEN='test.lapp' lapp-gen
 flag 'lines' value Int(10)
 flag 'verbose' value Bool(false)
 flag 'file' value Error("required flag file")
 flag 'help' value Bool(false)
-~/rust/lapp/examples$ LAPP_FILE='test.lapp' lapp-gen hello -v
+~/rust/lapp/examples$ LAPP_GEN='test.lapp' lapp-gen hello -v
 flag 'lines' value Int(10)
 flag 'verbose' value Bool(true)
 flag 'file' value Str("hello")
 flag 'help' value Bool(false)
-~/rust/lapp/examples$ LAPP_FILE='test.lapp' lapp-gen hello -v --lines 30
+~/rust/lapp/examples$ LAPP_GEN='test.lapp' lapp-gen hello -v --lines 30
 flag 'lines' value Int(30)
 flag 'verbose' value Bool(true)
 flag 'file' value Str("hello")
 flag 'help' value Bool(false)
-~/rust/lapp/examples$ LAPP_FILE='test.lapp' lapp-gen hello -vn 40
+~/rust/lapp/examples$ LAPP_GEN='test.lapp' lapp-gen hello -vn 40
 flag 'lines' value Int(40)
 flag 'verbose' value Bool(true)
 flag 'file' value Str("hello")
@@ -227,14 +227,14 @@ flag 'help' value Bool(false)
 
 ```
 
-The `mony.lapp` test file in `examples` gives all the permutations possible
+The `monty.lapp` test file in `examples` gives all the permutations possible
 with this version of Lapp.
 
 The real labour saving codegen option is to generate a struct which is initialized
 from lapp command-lines:
 
 ```rust
-~/rust/lapp/examples$ LAPP_FILE='test.lapp struct:Args' lapp-gen
+~/rust/lapp/examples$ LAPP_GEN='test.lapp struct:Args' lapp-gen
 ~/rust/lapp/examples$ cat test.lapp.inc
 const USAGE: &'static str = "
 Prints out first n lines of a file
@@ -295,6 +295,4 @@ Generally, however, I feel it's important to get a straightforward set of featur
 even if they are limited.  There are more general options for handling more complicated
 command-line programs (for example, that support commands like 'cargo build' or 'git status')
 and I intend to keep `lapp` as simple as possible, without extra dependencies.
-
-
 

--- a/src/bin/lapp-gen.rs
+++ b/src/bin/lapp-gen.rs
@@ -1,55 +1,81 @@
-// This little program has two purposes
-// First, it verifies the _lapp specification file_, which must be specified
-// in the environment variable LAPP_FILE. Any command-line arguments passed
-// are parsed and the results displayed.
-//
-// If LAPP_FILE contains that filename and an addition field separated by space,
-// then it generates code; if the extra field is 'vars', it prints out a set of
-// declarations that access the flags; if 'vars:STRUCT_NAME', it writes out a
-// suitable struct declaration for accessing the flags to a file 'SPEC-FILE.inc'.
-// It is meant to be brought into your program using 'include!'.
-//
-// See test.lapp
 extern crate lapp;
-use std::io;
 use std::env;
 use std::fs::File;
+use std::io;
 use std::io::prelude::*;
 
-fn main() {
-    let lapp_file_spec = env::var("LAPP_FILE").expect("please set LAPP_FILE env var");
-    let parts: Vec<_> = lapp_file_spec.split_whitespace().collect();
-    let mode = if parts.len() > 1 { parts[1] } else {""};
+const USAGE: &'static str = "
+lapp-gen, generate Rust code from lapp specification files
 
-    // first bit is the lapp command-line specification file
+ABOUT
+lapp-gen verifies lapp specifications and then allows testing and code generation based
+on those specifications.
+
+USAGE
+lapp-gen's behavior is specified using the environment variable `LAPP_GEN`; for instance:
+
+    LAPP_GEN=my_spec.lapp lapp-gen <args>
+
+LAPP_GEN can contain an additional field, seperated by a space. This is the code
+generation mode, which defaults to 'validate'.
+
+If lapp_gen is in 'validate' mode, any command-line arguments passed are parsed and the
+results displayed. This allows you to prototype a command-line interface rapidly.
+
+If the extra field is 'vars', it prints out a set of declarations that access the flags.
+If 'struct', it prints out a suitable struct declaration for accessing the flags, which
+is meant to be brought into your program using 'include!'.
+";
+
+enum Mode {
+    Validate,
+    Vars,
+    Struct,
+}
+
+fn main() {
+    // Get the user's instructions for what to do.
+    let lapp_file_spec = env::var("LAPP_GEN").unwrap_or_else(|_| {
+        print!("{}", USAGE);
+        ::std::process::exit(1);
+    });
+    let parts: Vec<_> = lapp_file_spec.split_whitespace().collect();
+
+    let mode = match if parts.len() > 1 {
+        parts[1]
+    } else {
+        "validate"
+    } {
+        "validate" => Mode::Validate,
+        "vars" => Mode::Vars,
+        "struct" => Mode::Struct,
+        _ => {
+            panic!("mode must be blank or one of 'validate', 'vars', or 'struct'");
+        }
+    };
+
+    // First part of the spec is the file to process.
     let lapp_file = parts[0];
-    let mut f = File::open(lapp_file).expect(&format!("cannot read {}",lapp_file));
+    let mut f = File::open(lapp_file).expect(&format!("Unable to open {}. Error", lapp_file));
     let mut txt = String::new();
-    f.read_to_string(&mut txt).expect("bad test.lapp");
+    f.read_to_string(&mut txt)
+        .expect(&format!("Unable to read UTF-8 from {}. Error", lapp_file));
 
     let mut args = lapp::Args::new(&txt);
 
-    if mode == "vars" || mode.starts_with("struct") {
-        let struct_name = if mode != "vars" {
-            match mode.find(':') {
-                Some(idx) => {
-                    let (_,s) = mode.split_at(idx+1);
-                    s
-                },
-                None => args.quit("must be struct:STRUCT_NAME")
-            }
-        } else {
-            ""
-        };
-        let dcls = args.declarations(struct_name);
-        if mode != "vars" {
-            let mut f = File::create(&format!("{}.inc",lapp_file)).expect("can't write");
-            f.write_all(&dcls.into_bytes()).expect("can't write");
-        } else {
-            io::stdout().write_all(&dcls.into_bytes()).expect("can't write");
+    match mode {
+        Mode::Vars => {
+            io::stdout()
+                .write_all(&args.declarations("").into_bytes())
+                .expect("Could not write to stdout. Error");
         }
-    } else {
-        args.dump();
-    }
-
+        Mode::Struct => {
+            io::stdout()
+                .write_all(&args.declarations("Args").into_bytes())
+                .expect("Could not write to stdout. Error");
+        }
+        Mode::Validate => {
+            args.dump();
+        }
+    };
 }

--- a/src/bin/lapp-gen.rs
+++ b/src/bin/lapp-gen.rs
@@ -36,7 +36,7 @@ enum Mode {
 fn main() {
     // Get the user's instructions for what to do.
     let lapp_file_spec = env::var("LAPP_GEN").unwrap_or_else(|_| {
-        print!("{}", USAGE);
+        eprint!("{}", USAGE);
         ::std::process::exit(1);
     });
     let parts: Vec<_> = lapp_file_spec.split_whitespace().collect();


### PR DESCRIPTION
Now the environment variable is LAPP_GEN, not LAPP_FILE, since it's more
than just a file, and when not passed a LAPP_GEN variable, it prints out
a usage text. Also, rather than writing a file itself with `struct`, it
simply prints to `stdout` so that users can redirect output where they
like.